### PR TITLE
FIX: Replace deprecation warning, replace ${var} with {$var} in string

### DIFF
--- a/Classes/Aspects/PropertyMapperAspect.php
+++ b/Classes/Aspects/PropertyMapperAspect.php
@@ -1,16 +1,11 @@
 <?php
+
 namespace Mireo\RepeatableFields\Aspects;
 
-use Mireo\RepeatableFields\Model\Repeatable;
 use Mireo\RepeatableFields\Service\NodePropertyHelper;
 use Neos\ContentRepository\Domain\Model\Node;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
-use Neos\Flow\Property\PropertyMapper;
-use Neos\Flow\Property\PropertyMappingConfiguration;
-use Neos\Neos\Domain\Service\ContentContext;
 
 /**
  * The central security aspect, that invokes the security interceptors.
@@ -27,41 +22,6 @@ class PropertyMapperAspect
      */
     protected NodePropertyHelper $nodePropertyHelper;
 
-//    /**
-//     * @Flow\Inject
-//     * @var PropertyMapper
-//     */
-//    protected $propertyMapper;
-//
-//    /**
-//     * @param NodeInterface $node
-//     * @param string $propertyName
-//     * @return mixed
-//     * @throws \Neos\ContentRepository\Exception\NodeException
-//     * @throws \Neos\Flow\Property\Exception
-//     * @throws \Neos\Flow\Security\Exception
-//     */
-//    protected function getRepeatableValue(NodeInterface $node, string $propertyName) : mixed{
-//        $nodeType = $node->getNodeType();
-//
-//        $explodedPropertyName = explode('.', $propertyName);
-//
-//        $expectedPropertyType = "repeatable";
-//        $value = $node->getNodeData()->getProperty($explodedPropertyName[0]);
-//        $configuration = new PropertyMappingConfiguration();
-//        $configuration->setTypeConverterOption('Mireo\RepeatableFields\TypeConverter\RepeatableConverter', 'context', $node->getContext());
-//        $properties = $nodeType->getConfiguration("properties.${explodedPropertyName[0]}.ui.inspector.editorOptions");
-//        $configuration->setTypeConverterOption('Mireo\RepeatableFields\TypeConverter\RepeatableConverter', 'properties', $properties);
-//        /** @var Repeatable $value */
-//        $value = $this->propertyMapper->convert($value, $expectedPropertyType, $configuration);
-//        if (isset($explodedPropertyName[1])) {
-//            array_shift($explodedPropertyName);
-//            return $value->offsetGet(implode(".",$explodedPropertyName));
-//        }else{
-//            return $value;
-//        }
-//    }
-
     /**
      * Proper property mapper for repeatable field
      * @Flow\Around("method(Neos\ContentRepository\Domain\Model\Node->getProperty())")
@@ -69,14 +29,15 @@ class PropertyMapperAspect
      * @throws
      * @return mixed The result of the target method if it has not been intercepted
      */
-    public function getProperty(JoinPointInterface $joinPoint) : mixed{
+    public function getProperty(JoinPointInterface $joinPoint): mixed
+    {
         $propertyName = $joinPoint->getMethodArgument('propertyName');
         /** @var Node $node */
         $node = $joinPoint->getProxy();
 
         $explodedPropertyName = explode('.', $propertyName);
-        if( $explodedPropertyName ) {
 
+        if ($explodedPropertyName) {
             $expectedPropertyType = $node->getNodeType()->getPropertyType($explodedPropertyName[0]);
 
             if ($expectedPropertyType == 'repeatable') {
@@ -97,9 +58,10 @@ class PropertyMapperAspect
      * @throws
      * @return mixed The result of the target method if it has not been intercepted
      */
-    public function findFirstEligibleTypeConverterInObjectHierarchy(JoinPointInterface $joinPoint){
+    public function findFirstEligibleTypeConverterInObjectHierarchy(JoinPointInterface $joinPoint)
+    {
         $targetType = $joinPoint->getMethodArgument('targetType');
-        if( $targetType == 'repeatable' || $targetType == 'Mireo\RepeatableFields\Model\Repeatable' ){
+        if ($targetType == 'repeatable' || $targetType == 'Mireo\RepeatableFields\Model\Repeatable') {
             $targetType = 'repeatable';
             $joinPoint->setMethodArgument('sourceType', $targetType);
             $targetType = 'Mireo\RepeatableFields\Model\Repeatable';

--- a/Classes/Service/NodePropertyHelper.php
+++ b/Classes/Service/NodePropertyHelper.php
@@ -24,7 +24,8 @@ class NodePropertyHelper
      * @throws \Neos\Flow\Property\Exception
      * @throws \Neos\Flow\Security\Exception
      */
-    public function getRepeatableValue(NodeInterface $node, string $propertyName){
+    public function getRepeatableValue(NodeInterface $node, string $propertyName)
+    {
         $nodeType = $node->getNodeType();
 
         $explodedPropertyName = explode('.', $propertyName);
@@ -33,15 +34,15 @@ class NodePropertyHelper
         $value = $node->getNodeData()->getProperty($explodedPropertyName[0]);
         $configuration = new PropertyMappingConfiguration();
         $configuration->setTypeConverterOption('Mireo\RepeatableFields\TypeConverter\RepeatableConverter', 'context', $node->getContext());
-        $properties = $nodeType->getConfiguration("properties.${explodedPropertyName[0]}.ui.inspector.editorOptions");
+        $properties = $nodeType->getConfiguration("properties.{$explodedPropertyName[0]}.ui.inspector.editorOptions");
         $configuration->setTypeConverterOption('Mireo\RepeatableFields\TypeConverter\RepeatableConverter', 'properties', $properties);
         /** @var Repeatable $value */
         $value = $this->propertyMapper->convert($value, $expectedPropertyType, $configuration);
         if (isset($explodedPropertyName[1])) {
             array_shift($explodedPropertyName);
-            return $value->offsetGet(implode(".",$explodedPropertyName));
-        }else{
-            return $value;
+            return $value->offsetGet(implode(".", $explodedPropertyName));
         }
+
+        return $value;
     }
 }


### PR DESCRIPTION
This fix removes some outdated code and fixes a deprecation warning in PHP 8 because using `${var}` in strings is deprecated. 

This also fixes #18. 