### PR TITLE
BUGFIX: Store nullish default values for properties

### DIFF
--- a/Resources/Private/Backend/RepeatableField/src/View/Repeatable.js
+++ b/Resources/Private/Backend/RepeatableField/src/View/Repeatable.js
@@ -158,7 +158,7 @@ export default class Repeatable extends PureComponent {
 			const { properties } = props.options;
 			if (properties) {
 				Object.keys(properties).map((property, index) => {
-					this.emptyGroup[property] = properties[property].defaultValue
+					this.emptyGroup[property] = properties[property].defaultValue !== undefined
 						? properties[property].defaultValue
 						: "";
 				});


### PR DESCRIPTION
This concerns values like `null`, `0` and `false` which were not stored without this change.

Resolves: #21 