### PR TITLE
TASK: Fix PHP deprecated warning

### DIFF
--- a/Classes/Service/NodePropertyHelper.php
+++ b/Classes/Service/NodePropertyHelper.php
@@ -34,7 +34,7 @@ class NodePropertyHelper
         $value = $node->getNodeData()->getProperty($explodedPropertyName[0]);
         $configuration = new PropertyMappingConfiguration();
         $configuration->setTypeConverterOption('Mireo\RepeatableFields\TypeConverter\RepeatableConverter', 'context', $node->getContext());
-        $properties = $nodeType->getConfiguration("properties.{$explodedPropertyName[0]}.ui.inspector.editorOptions");
+        $properties = $nodeType->getConfiguration(sprintf('properties.%s.ui.inspector.editorOptions', $explodedPropertyName[0]));
         $configuration->setTypeConverterOption('Mireo\RepeatableFields\TypeConverter\RepeatableConverter', 'properties', $properties);
         /** @var Repeatable $value */
         $value = $this->propertyMapper->convert($value, $expectedPropertyType, $configuration);


### PR DESCRIPTION
This removes the warning

`PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead`