### PR TITLE
fix: asset usage count

### DIFF
--- a/Classes/Aspects/AssetUsageAspect.php
+++ b/Classes/Aspects/AssetUsageAspect.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Mireo\RepeatableFields\Aspects;
+
+use Mireo\RepeatableFields\Service\RepeatableAssetUsageHelper;
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+use Neos\Media\Domain\Model\AssetInterface;
+
+/**
+ * Aspect to extend asset usage detection to support repeatable fields
+ *
+ * @Flow\Scope("singleton")
+ * @Flow\Aspect
+ */
+class AssetUsageAspect
+{
+    /**
+     * @Flow\Inject
+     * @var RepeatableAssetUsageHelper
+     */
+    protected $repeatableAssetUsageHelper;
+
+    /**
+     * Extend the getRelatedNodes method to also find assets in repeatable fields
+     *
+     * @Flow\Around("method(Neos\Neos\Domain\Strategy\AssetUsageInNodePropertiesStrategy->getRelatedNodes())")
+     * @param JoinPointInterface $joinPoint
+     * @return array<NodeData>
+     */
+    public function extendGetRelatedNodes(JoinPointInterface $joinPoint): array
+    {
+        $originalNodes = $joinPoint->getAdviceChain()->proceed($joinPoint);
+        /** @var AssetInterface $asset */
+        $asset = $joinPoint->getMethodArgument('asset');
+        $repeatableFieldNodes = $this->repeatableAssetUsageHelper->findNodesWithAssetInRepeatableFields($asset);
+
+        $allNodes = $originalNodes;
+        $existingIdentifiers = array_map(fn($node) => $node->getIdentifier(), $originalNodes);
+
+        foreach ($repeatableFieldNodes as $node) {
+            if (!in_array($node->getIdentifier(), $existingIdentifiers, true)) {
+                $allNodes[] = $node;
+            }
+        }
+
+        return $allNodes;
+    }
+}

--- a/Classes/Service/RepeatableAssetUsageHelper.php
+++ b/Classes/Service/RepeatableAssetUsageHelper.php
@@ -1,0 +1,82 @@
+<?php
+namespace Mireo\RepeatableFields\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Model\Image;
+use Neos\Neos\Domain\Service\SiteService;
+
+/**
+ * Helper class for finding asset usage in repeatable fields
+ *
+ * @Flow\Scope("singleton")
+ */
+class RepeatableAssetUsageHelper
+{
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
+
+    /**
+     * @Flow\Inject
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * Find nodes that use the asset in repeatable field properties
+     *
+     * Repeatable fields store assets in two formats:
+     * - As objects: "__identity": "uuid" (images)
+     * - As plain strings: "uuid" (videos, PDFs, other assets)
+     *
+     * @param AssetInterface $asset
+     * @return array<NodeData>
+     */
+    public function findNodesWithAssetInRepeatableFields(AssetInterface $asset): array
+    {
+        $assetIdentifier = $this->persistenceManager->getIdentifierByObject($asset);
+        $identifiers = [$assetIdentifier];
+
+        if ($asset instanceof Image) {
+            foreach ($asset->getVariants() as $variant) {
+                $identifiers[] = $this->persistenceManager->getIdentifierByObject($variant);
+            }
+        }
+
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $queryBuilder->select('n')
+            ->from(NodeData::class, 'n')
+            ->where('n.path LIKE :pathPrefix');
+
+        $queryBuilder->setParameter('pathPrefix', SiteService::SITES_ROOT_PATH . '%');
+
+        $constraints = [];
+        $parameters = ['pathPrefix' => SiteService::SITES_ROOT_PATH . '%'];
+        $identifierIndex = 0;
+
+        foreach ($identifiers as $identifier) {
+            $lowerIdentifier = strtolower($identifier);
+
+            $constraints[] = '(LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :identity' . $identifierIndex . ')';
+            $parameters['identity' . $identifierIndex] = '%"__identity": "' . $lowerIdentifier . '"%';
+            $identifierIndex++;
+
+            $constraints[] = '(LOWER(NEOSCR_TOSTRING(n.properties)) LIKE :plain' . $identifierIndex . ')';
+            $parameters['plain' . $identifierIndex] = '%": "' . $lowerIdentifier . '"%';
+            $identifierIndex++;
+        }
+
+        if (!empty($constraints)) {
+            $queryBuilder->andWhere(implode(' OR ', $constraints));
+            $queryBuilder->setParameters($parameters);
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+}


### PR DESCRIPTION
Currently, assets inside repeatable fields are not counted towards asset usage. This means that it is possible to delete assets that are actually in use.

This PR extends the query to display assets in use within the media module.

**Example**

This image is selected as a property of type `ImageInterface` inside a repeatable field. It now correctly shows its references. Before it was possible to delete the image since the media module wasn't aware of any relations.

<img width="516" height="383" alt="image" src="https://github.com/user-attachments/assets/5ccae34a-7a5a-4cba-b01a-06ba549f0953" />
